### PR TITLE
Fixes the Benchmark App to Work with NNBD

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ implementation details. Later in this document, we provide benchmarks so that yo
 </p>
 
 <p align="center">
-  <sub>The <a href="https://github.com/marcglasberg/fast_immutable_collections/tree/master/example/benchmark/benchmark_app"><code>benchmark_app</code></a> compares the performance of FIC to other packages</sub>
+  <sub>The <a href="https://github.com/marcglasberg/fast_immutable_collections/tree/master/example/benchmark/benchmark_app"><code>benchmark_app</code></a> compares FIC's performance to other packages &mdash; you might need to run it with <code>flutter run --no-sound-null-safety</code> since some of its dependencies haven't yet transitioned into NNBD.</sub>
 </p>
 
 [built_collection]: https://pub.dev/packages/built_collection

--- a/example/benchmark/benchmark_app/README.md
+++ b/example/benchmark/benchmark_app/README.md
@@ -2,6 +2,8 @@
 
 ![GIF][gif]
 
+> You might need to run it with `flutter run --no-sound-null-safety` since some of its dependencies haven't yet transitioned into NNBD.
+
 The example project for the [`fast_immutable_collections_benchmarks`][fast_immutable_collections_benchmarks] package.
 
 This app is meant to be played as a benchmark for the [`fast_immutable_collections`][fast_immutable_collections] package.

--- a/example/benchmark/benchmark_app/lib/widgets/bench_widget.dart
+++ b/example/benchmark/benchmark_app/lib/widgets/bench_widget.dart
@@ -27,8 +27,8 @@ class BenchWidget extends StatefulWidget {
 // ////////////////////////////////////////////////////////////////////////////
 
 class _BenchWidgetState extends State<BenchWidget> {
-  late bool _isRunning = false;
-  late List<RecordsTable>? _results;
+  bool _isRunning = false;
+  List<RecordsTable>? _results;
 
   Future<void> _goToResults() => Navigator.of(context).push(
         MaterialPageRoute(

--- a/lib/src/iset/set_extension.dart
+++ b/lib/src/iset/set_extension.dart
@@ -1,4 +1,4 @@
-import 'package:collection/equality.dart';
+import 'package:collection/collection.dart';
 
 import "iset.dart";
 


### PR DESCRIPTION
As mentioned in the README, you might need to add the parameter `--no-sound-null-safety` to make the app run work. That's because some of its dependencies have not yet transitioned into NNBD.

For more info do check the [Unsound null safety][unsound_null_safety] article.


[unsound_null_safety]: https://dart.dev/null-safety/unsound-null-safety#testing-or-running-mixed-version-programs