### PR TITLE
add conversion of non-string keys for maps

### DIFF
--- a/json_serializable_e2e_test/lib/src/model/ilist_model.dart
+++ b/json_serializable_e2e_test/lib/src/model/ilist_model.dart
@@ -9,7 +9,8 @@ class IListWrapper {
 
   IListWrapper(this.iList);
 
-  factory IListWrapper.fromJson(Map<String, dynamic> json) => _$IListWrapperFromJson(json);
+  factory IListWrapper.fromJson(Map<String, dynamic> json) =>
+      _$IListWrapperFromJson(json);
 
   Map<String, dynamic> toJson() => _$IListWrapperToJson(this);
 }
@@ -20,9 +21,22 @@ class IMapWrapper {
 
   IMapWrapper(this.iMap);
 
-  factory IMapWrapper.fromJson(Map<String, dynamic> json) => _$IMapWrapperFromJson(json);
+  factory IMapWrapper.fromJson(Map<String, dynamic> json) =>
+      _$IMapWrapperFromJson(json);
 
   Map<String, dynamic> toJson() => _$IMapWrapperToJson(this);
+}
+
+@JsonSerializable()
+class IMapWrapper2 {
+  final IMap<int, String> iMap;
+
+  IMapWrapper2(this.iMap);
+
+  factory IMapWrapper2.fromJson(Map<String, dynamic> json) =>
+      _$IMapWrapper2FromJson(json);
+
+  Map<String, dynamic> toJson() => _$IMapWrapper2ToJson(this);
 }
 
 @JsonSerializable()
@@ -31,7 +45,8 @@ class ISetWrapper {
 
   ISetWrapper(this.iSet);
 
-  factory ISetWrapper.fromJson(Map<String, dynamic> json) => _$ISetWrapperFromJson(json);
+  factory ISetWrapper.fromJson(Map<String, dynamic> json) =>
+      _$ISetWrapperFromJson(json);
 
   Map<String, dynamic> toJson() => _$ISetWrapperToJson(this);
 }

--- a/json_serializable_e2e_test/lib/src/model/ilist_model.g.dart
+++ b/json_serializable_e2e_test/lib/src/model/ilist_model.g.dart
@@ -6,11 +6,9 @@ part of 'ilist_model.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-IListWrapper _$IListWrapperFromJson(Map<String, dynamic> json) {
-  return IListWrapper(
-    IList.fromJson(json['iList'], (value) => value as String),
-  );
-}
+IListWrapper _$IListWrapperFromJson(Map<String, dynamic> json) => IListWrapper(
+      IList<String>.fromJson(json['iList'], (value) => value as String),
+    );
 
 Map<String, dynamic> _$IListWrapperToJson(IListWrapper instance) =>
     <String, dynamic>{
@@ -19,12 +17,10 @@ Map<String, dynamic> _$IListWrapperToJson(IListWrapper instance) =>
       ),
     };
 
-IMapWrapper _$IMapWrapperFromJson(Map<String, dynamic> json) {
-  return IMapWrapper(
-    IMap.fromJson(json['iMap'] as Map<String, dynamic>,
-        (value) => value as String, (value) => value as String),
-  );
-}
+IMapWrapper _$IMapWrapperFromJson(Map<String, dynamic> json) => IMapWrapper(
+      IMap<String, String>.fromJson(json['iMap'] as Map<String, dynamic>,
+          (value) => value as String, (value) => value as String),
+    );
 
 Map<String, dynamic> _$IMapWrapperToJson(IMapWrapper instance) =>
     <String, dynamic>{
@@ -34,11 +30,22 @@ Map<String, dynamic> _$IMapWrapperToJson(IMapWrapper instance) =>
       ),
     };
 
-ISetWrapper _$ISetWrapperFromJson(Map<String, dynamic> json) {
-  return ISetWrapper(
-    ISet.fromJson(json['iSet'], (value) => value as String),
-  );
-}
+IMapWrapper2 _$IMapWrapper2FromJson(Map<String, dynamic> json) => IMapWrapper2(
+      IMap<int, String>.fromJson(json['iMap'] as Map<String, dynamic>,
+          (value) => value as int, (value) => value as String),
+    );
+
+Map<String, dynamic> _$IMapWrapper2ToJson(IMapWrapper2 instance) =>
+    <String, dynamic>{
+      'iMap': instance.iMap.toJson(
+        (value) => value,
+        (value) => value,
+      ),
+    };
+
+ISetWrapper _$ISetWrapperFromJson(Map<String, dynamic> json) => ISetWrapper(
+      ISet<String>.fromJson(json['iSet'], (value) => value as String),
+    );
 
 Map<String, dynamic> _$ISetWrapperToJson(ISetWrapper instance) =>
     <String, dynamic>{

--- a/json_serializable_e2e_test/test/ilist_test.dart
+++ b/json_serializable_e2e_test/test/ilist_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:json_serializable_e2e_test/src/model/ilist_model.dart';
 import 'package:test/test.dart';
@@ -54,6 +56,13 @@ void main() {
               'c': 'd',
             }
           });
+      expect(
+          jsonEncode(IMapWrapper2({
+            1: 'b',
+            2: 'd',
+          }.lock)
+              .toJson()),
+          '''{"iMap":{"1":"b","2":"d"}}''');
     });
 
     test('can deserialize IMap', () {
@@ -67,6 +76,14 @@ void main() {
           IMap({
             'a': 'b',
             'c': 'd',
+          }));
+          expect(
+          IMapWrapper2.fromJson(jsonDecode(
+            '''{"iMap":{"1":"b","2":"d"}}'''
+          )).iMap,
+          IMap({
+            1: 'b',
+            2: 'd',
           }));
     });
   });


### PR DESCRIPTION
This solves an issue where keys of maps are not converted to Strings which are the only valid json map key.