### PR TITLE
Add support for enums to compareObject function

### DIFF
--- a/lib/src/base/sort.dart
+++ b/lib/src/base/sort.dart
@@ -4,7 +4,7 @@ import "package:fast_immutable_collections/fast_immutable_collections.dart";
 /// provided by [Comparable] objects in their [Comparable.compareTo] method,
 /// to sort objects in their "natural order". The difference here is that
 /// [compareObject] is also able to compare some objects which are not
-/// [Comparable], such as [bool], [MapEntry], and nulls.
+/// [Comparable], such as [bool], [MapEntry], [Enum], and nulls.
 ///
 /// In more detail:
 ///
@@ -21,7 +21,9 @@ import "package:fast_immutable_collections/fast_immutable_collections.dart";
 /// 4. Otherwise, if [a] and [b] are booleans, compare them such as `true`
 /// comes after `false`.
 ///
-/// 5. Otherwise, return `0`, which means **unordered**.
+/// 5. Otherwise, if [a] and [b] are of the same enum type, compare them by their name.
+///
+/// 6. Otherwise, return `0`, which means **unordered**.
 ///
 /// Example:
 ///
@@ -47,6 +49,7 @@ int compareObject<T extends Object>(
   if (a is MapEntry && b is MapEntry)
     return compareObject(a.key, b.key).if0(compareObject(a.value, b.value));
   if (a is bool && b is bool) return a.compareTo(b);
+  if (a is Enum && b.runtimeType == a.runtimeType) return a.name.compareTo((b as Enum).name);
   return 0;
 }
 

--- a/lib/src/ilist/ilist_of_2.dart
+++ b/lib/src/ilist/ilist_of_2.dart
@@ -53,7 +53,7 @@ class Tuple2<T1, T2> extends Tuple {
     else if (i == 1)
       return second;
     else
-      throw IndexError.withLength(i, 2, indexable: this);
+      throw IndexError(i, this, null, null, /* length: */ 2);
   }
 
   /// Create a new tuple value with the specified list [items].

--- a/test/base/sort_test.dart
+++ b/test/base/sort_test.dart
@@ -52,6 +52,12 @@ void main() {
           ..shuffle()
           ..sort(compareObject),
         [entryA10, entryA20]);
+
+    // 7) Enums are sorted
+    expect(
+      [TestEnum.foo, TestEnum.bar]..sort(compareObject),
+      [TestEnum.bar, TestEnum.foo]..sort(compareObject)
+    );
   });
 
   //////////////////////////////////////////////////////////////////////////////
@@ -266,4 +272,8 @@ void main() {
   });
 
   //////////////////////////////////////////////////////////////////////////////
+}
+
+enum TestEnum {
+  foo, bar
 }


### PR DESCRIPTION
This is helpful, whenever you want to use an `ISet` with `sort: true` in its config when the items are of a certain `enum`.