### PR TITLE
fix types in sumBy to enable summing a list full of doubles

### DIFF
--- a/lib/src/base/iterable_extension.dart
+++ b/lib/src/base/iterable_extension.dart
@@ -136,11 +136,11 @@ extension FicIterableExtension<T> on Iterable<T> {
   /// expect(['a', 'ab', 'abc', 'abcd', 'abcde'].sumBy((e) => e.length), 15);
   /// ```
   N sumBy<N extends num>(N Function(T element) mapper) {
-    N result = 0 as N;
+    num result = 0;
     for (final value in this) {
-      result = result + mapper(value) as N;
+      result = result + mapper(value);
     }
-    return result;
+    return result as N;
   }
 
   /// The arithmetic mean of the elements of a non-empty iterable.

--- a/test/base/iterable_extension_test.dart
+++ b/test/base/iterable_extension_test.dart
@@ -29,6 +29,7 @@ void main() {
   test('sumBy', () {
     expect([1, 2, 3, 4, 5].sumBy((e) => e), 15);
     expect([1.5, 2.5, 3.3, 4, 5].sumBy((e) => e), 16.3);
+    expect([1.5, 2.5, 3.3, 4.2, 5.9].sumBy((e) => e), 17.4);
     expect([].sumBy((e) => (e is int) ? e : 0), 0);
     expect([''].sumBy((e) => e.length), 0);
     expect(['a'].sumBy((e) => e.length), 1);


### PR DESCRIPTION
### What was the problem ? 
When using sumBy on a list where the mapper function would return only doubles, the method throws an error.
**The error is :**
```sh
type 'int' is not a subtype of type 'double' in type cast
package:fast_immutable_collections/src/base/iterable_extension.dart 139:18  FicIterableExtension.sumBy
test/base/iterable_extension_test.dart 30:38                                main.<fn>
```

**Code in error :**
```dart
  N sumBy<N extends num>(N Function(T element) mapper) {
    N result = 0 as N; // <- the code that throws the error
    ...
  }
```

**Step to reproduce :**
```dart
[1.5, 2.5, 3.3, 4.3, 5.3].sumBy((e) => e)
```

**Reason :**
If the list only has double, type N is double and the type cast of 0 fails


