### PR TITLE
feat: IList.empty() const factory

### DIFF
--- a/lib/src/ilist/ilist.dart
+++ b/lib/src/ilist/ilist.dart
@@ -201,7 +201,7 @@ abstract class IList<T> // ignore: must_be_immutable
 
   /// Create an empty [IList].
   /// It is always a constant list.
-  const factory IList.empty() = IListConst.empty;
+  const factory IList.empty() = IListConst<T>.empty;
 
   const IList._gen();
 

--- a/lib/src/ilist/ilist.dart
+++ b/lib/src/ilist/ilist.dart
@@ -36,6 +36,14 @@ class IListConst<T> // ignore: must_be_immutable
 
   final List<T> _list;
 
+  /// Creates a empty constant list.
+  ///
+  /// IMPORTANT: You must always use the `const` keyword.
+  /// It's always wrong to use an `IListConst.empty()` which is not constant.
+  const IListConst.empty([this.config = const ConfigList()])
+      : _list = const [],
+        super._gen();
+
   @override
   final ConfigList config;
 
@@ -189,6 +197,11 @@ abstract class IList<T> // ignore: must_be_immutable
   ///
   factory IList([Iterable<T>? iterable]) => //
       IList.withConfig(iterable ?? const [], defaultConfig);
+
+
+  /// Create an empty [IList].
+  /// It is always a constant list.
+  const factory IList.empty() = IListConst.empty;
 
   const IList._gen();
 

--- a/test/ilist/ilist_test.dart
+++ b/test/ilist/ilist_test.dart
@@ -26,6 +26,10 @@ void main() {
     expect(IList<int>.empty(), isA<IList<int>>());
     expect(const IList.empty(), isA<IList>());
     expect(const IList<int>.empty(), isA<IList<int>>());
+    const IList untypedList = IList.empty();
+    expect(untypedList, isA<IList>());
+    const IList<int> intList = IList.empty();
+    expect(intList, isA<IList<int>>());
   });
 
   test("isEmpty | isNotEmpty", () {

--- a/test/ilist/ilist_test.dart
+++ b/test/ilist/ilist_test.dart
@@ -22,6 +22,10 @@ void main() {
     expect(IList([1]), isA<IList<int>>());
     expect(IList<int>(), isA<IList<int>>());
     expect([].lock, isA<IList>());
+    expect(IList.empty(), isA<IList>());
+    expect(IList<int>.empty(), isA<IList<int>>());
+    expect(const IList.empty(), isA<IList>());
+    expect(const IList<int>.empty(), isA<IList<int>>());
   });
 
   test("isEmpty | isNotEmpty", () {
@@ -42,6 +46,18 @@ void main() {
 
     expect([].lock.isEmpty, isTrue);
     expect([].lock.isNotEmpty, isFalse);
+
+    expect(IList.empty().isEmpty, isTrue);
+    expect(IList.empty().isNotEmpty, isFalse);
+
+    expect(const IList.empty().isEmpty, isTrue);
+    expect(const IList.empty().isNotEmpty, isFalse);
+
+    expect(IList<String>.empty().isEmpty, isTrue);
+    expect(IList<String>.empty().isNotEmpty, isFalse);
+
+    expect(const IList<String>.empty().isEmpty, isTrue);
+    expect(const IList<String>.empty().isNotEmpty, isFalse);
   });
 
   test("Ensuring Immutability", () {


### PR DESCRIPTION
I've read https://github.com/marcglasberg/fast_immutable_collections/issues/38 and decided to give the IList.empty() const factory a try. It seems to work. If this matches your vision for the package, i'd try to implement the same approach for the other collection types