### PR TITLE
Enable empty lists inferred as double (eg: <double>[]) to return a zero of type double

### DIFF
--- a/lib/src/base/iterable_extension.dart
+++ b/lib/src/base/iterable_extension.dart
@@ -136,11 +136,30 @@ extension FicIterableExtension<T> on Iterable<T> {
   /// expect(['a', 'ab', 'abc', 'abcd', 'abcde'].sumBy((e) => e.length), 15);
   /// ```
   N sumBy<N extends num>(N Function(T element) mapper) {
+    // If the iterable is empty but N is double
+    // then result will be an int because 0 is an int
+    // therefore result as N (which in this case will be: 0 as double)
+    // will throw an error
+    if (isEmpty) {
+      return _zeroOf<N>();
+    }
+
     num result = 0;
     for (final value in this) {
       result = result + mapper(value);
     }
     return result as N;
+  }
+
+  /// Returns a zero of type [N]. 
+  N _zeroOf<N extends num>() {
+    // num is a sealed class with only two subclasses: int and double
+    // therefore this function should never throw
+    return switch (N) {
+      const (int) => 0 as N,
+      const (double) => 0.0 as N,
+      _ => throw UnsupportedError("Unsupported type: $N"),
+    };
   }
 
   /// The arithmetic mean of the elements of a non-empty iterable.

--- a/test/base/iterable_extension_test.dart
+++ b/test/base/iterable_extension_test.dart
@@ -35,6 +35,8 @@ void main() {
     expect(['a'].sumBy((e) => e.length), 1);
     expect(['a', 'ab', 'abc', 'abcd', 'abcde'].sumBy((e) => e.length), 15);
     expect(['a', 'ab', 'abc', 'abcd', 'abcde'].map((e) => e.length).sum, 15);
+    expect(<double>[].sumBy((e) => e), 0.0);
+    expect(<int>[].sumBy((e) => e), 0);
   });
 
   test('averageBy', () {


### PR DESCRIPTION
*I noticed that the CI is failing but doesn't seem to be caused by the modified code.*

### What was the problem ? 
When using sumBy on an empty list with a type inferred as `Iterable<double>`, the method throws an error.
**The error is :**
```sh
type 'int' is not a subtype of type 'double' in type cast
```

**Code in error :**
```dart
N sumBy<N extends num>(N Function(T element) mapper) {
  ...
  return result as N; // located in: /lib/src/base/iterable_extension.dart:148
}
```

**Step to reproduce :**
```dart
<double>[].sumBy((e) => e)
```

**Reason :**
If the list is empty, the for loop will not be entered and the return will do `return result as double;` however `result` equals 0 and has type int at runtime. 

**Fix :**
I propose to add an early return when the list is empty, we return either a zero from int or a zero from double depending on the type N is equal to. I had to create a small method that gets the expected zero since I did not find any better solution. 
