### PR TITLE
feat: Allow zip method different type

### DIFF
--- a/lib/src/ilist/ilist.dart
+++ b/lib/src/ilist/ilist.dart
@@ -1795,7 +1795,7 @@ abstract class IList<T> // ignore: must_be_immutable
       Iterable.generate(length, (index) => (index, _l[index])).toIList(config);
 
   /// Aggregate two sources trimming by the shortest source
-  Iterable<(T, T)> zip(Iterable<T> otherIterable) {
+  Iterable<(T, U)> zip<U>(Iterable<U> otherIterable) {
     final other = otherIterable.toList();
     final minLength = min(length, other.length);
     return Iterable.generate(minLength, (index) => (_l[index], other[index])).toIList(config);

--- a/test/ilist/ilist_test.dart
+++ b/test/ilist/ilist_test.dart
@@ -1567,6 +1567,17 @@ void main() {
           ('France', 'Paris'),
           ('Germany', 'Berlin'),
         ]));
+
+    // different type
+    final Iterable<(String, int)> zipped = countries.zip([10, 20, 30, 40]);
+    expect(
+        zipped,
+        IList([
+          ('France', 10),
+          ('Germany', 20),
+          ('Brazil', 30),
+          ('Japan', 40)
+        ]));
   });
 
   test("ZipAll with another source replacing with fill method value if available or else null", () {

--- a/test/ilist/ilist_test.dart
+++ b/test/ilist/ilist_test.dart
@@ -1569,9 +1569,9 @@ void main() {
         ]));
 
     // different type
-    final Iterable<(String, int)> zipped = countries.zip([10, 20, 30, 40]);
+    final Iterable<(String, int)> zippedWithInt = countries.zip([10, 20, 30, 40]);
     expect(
-        zipped,
+        zippedWithInt,
         IList([
           ('France', 10),
           ('Germany', 20),


### PR DESCRIPTION
```dart
final countries = ['France', 'Germany', 'Brazil', 'Japan'].lock;

final Iterable<(String, int)> zipped = countries.zip([10, 20, 30, 40]);
expect(
  zipped,
  IList([
    ('France', 10),
    ('Germany', 20),
    ('Brazil', 30),
    ('Japan', 40),
  ]),
);
```

## Examples of zip functions in other languages
- Haskell `zip :: [a] -> [b] -> [(a, b)]` https://hackage.haskell.org/package/base-4.19.1.0/docs/Prelude.html#v:zip
- PureScript `zip :: forall a b. Array a -> Array b -> Array (Tuple a b)` https://pursuit.purescript.org/packages/purescript-arrays/7.3.0/docs/Data.Array#v:zip
- Elm `zip : List a -> List b -> List ( a, b )` https://package.elm-lang.org/packages/elm-community/list-extra/latest/List-Extra#zip